### PR TITLE
Add weather tab

### DIFF
--- a/cmd/weather.go
+++ b/cmd/weather.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+    "EXCHANGETURKEY/weather"
+    "fmt"
+
+    "github.com/spf13/cobra"
+)
+
+// weatherCmd represents the weather command
+var weatherCmd = &cobra.Command{
+    Use:   "hava",
+    Short: "Hava durumunu gosterir",
+    Run: func(cmd *cobra.Command, args []string) {
+        country, _ := cmd.Flags().GetString("country")
+        city, _ := cmd.Flags().GetString("city")
+        if city == "" {
+            fmt.Println("City is required")
+            return
+        }
+        info := weather.GetWeather(country, city)
+        fmt.Println(info)
+    },
+}
+
+func init() {
+    rootCmd.AddCommand(weatherCmd)
+    weatherCmd.Flags().StringP("country", "c", "", "Ulke adi")
+    weatherCmd.Flags().StringP("city", "i", "", "Sehir adi")
+}
+

--- a/weather/weather.go
+++ b/weather/weather.go
@@ -1,0 +1,32 @@
+package weather
+
+import (
+    "fmt"
+    "io"
+    "net/http"
+    "time"
+)
+
+// GetWeather fetches weather information from wttr.in for the given country and city.
+// Country can be empty. City must not be empty.
+func GetWeather(country, city string) string {
+    location := city
+    if country != "" {
+        location = fmt.Sprintf("%s,%s", city, country)
+    }
+    url := fmt.Sprintf("https://wttr.in/%s?format=3", location)
+
+    client := &http.Client{Timeout: 10 * time.Second}
+    resp, err := client.Get(url)
+    if err != nil {
+        return fmt.Sprintf("request error: %v", err)
+    }
+    defer resp.Body.Close()
+
+    body, err := io.ReadAll(resp.Body)
+    if err != nil {
+        return fmt.Sprintf("read error: %v", err)
+    }
+    return string(body)
+}
+


### PR DESCRIPTION
## Summary
- add `hava` CLI tab for weather
- fetch weather using wttr.in in a new `weather` package

## Testing
- `go vet ./...` *(fails: github.com/PuerkitoBio/goquery@v1.8.0: Get "https://proxy.golang.org/github.com/%21puerkito%21bio/goquery/@v/v1.8.0.zip": Forbidden)*
- `go build ./...` *(fails: github.com/PuerkitoBio/goquery@v1.8.0: Get "https://proxy.golang.org/github.com/%21puerkito%21bio/goquery/@v/v1.8.0.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684018e53f188330b083a7237303aaa7